### PR TITLE
[Bugfix] Fix display large numbers

### DIFF
--- a/lib/screens/shared/media/components/poster_image.dart
+++ b/lib/screens/shared/media/components/poster_image.dart
@@ -361,13 +361,14 @@ class _PosterImageState extends ConsumerState<PosterImage> {
                     alignment: Alignment.topRight,
                     child: StatusCard(
                       color: Theme.of(context).colorScheme.primary,
+                      useFittedBox: widget.poster.unPlayedItemCount != 0,
                       child: Padding(
                         padding: const EdgeInsets.all(6),
                         child: widget.poster.unPlayedItemCount != 0
-                            ? Container(
-                                constraints: const BoxConstraints(minWidth: 18),
+                            ? Container(                                
+                                constraints: const BoxConstraints(minWidth: 16),
                                 child: Text(
-                                  widget.poster.userData.unPlayedItemCount.toString(),
+                                  widget.poster.userData.unPlayedItemCount.toString(),                                   
                                   textAlign: TextAlign.center,
                                   style: TextStyle(
                                     color: Theme.of(context).colorScheme.primary,

--- a/lib/screens/shared/media/season_row.dart
+++ b/lib/screens/shared/media/season_row.dart
@@ -101,6 +101,7 @@ class SeasonPoster extends ConsumerWidget {
                       alignment: Alignment.topRight,
                       child: StatusCard(
                         color: Theme.of(context).colorScheme.primary,
+                        useFittedBox: true,
                         child: Center(
                           child: Text(
                             season.userData.unPlayedItemCount.toString(),

--- a/lib/widgets/shared/status_card.dart
+++ b/lib/widgets/shared/status_card.dart
@@ -13,7 +13,7 @@ class StatusCard extends ConsumerWidget {
     return Padding(
       padding: const EdgeInsets.all(5),
       child: SizedBox(
-        width: 33,
+        width: 40,
         height: 33,
         child: Card(
           elevation: 10,

--- a/lib/widgets/shared/status_card.dart
+++ b/lib/widgets/shared/status_card.dart
@@ -3,9 +3,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class StatusCard extends ConsumerWidget {
   final Color? color;
+  final bool useFittedBox;
   final Widget child;
 
-  const StatusCard({this.color, required this.child, super.key});
+  const StatusCard({this.color, this.useFittedBox = false, required this.child, super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -22,7 +23,14 @@ class StatusCard extends ConsumerWidget {
             data: IconThemeData(
               color: color,
             ),
-            child: Center(child: child),
+            child: Center(
+              child: useFittedBox
+                  ? FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: child,
+                    )
+                  : child,
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
Fix the error when display large numbers #5 

Example: 
![image](https://github.com/user-attachments/assets/78cfd283-680f-4d51-88e4-89a178d2e732)

The numbers in the example image was random generated.