### PR TITLE
[Bugfix] Mobile - Fixed navigating back to splash screen

### DIFF
--- a/lib/routes/auto_router.dart
+++ b/lib/routes/auto_router.dart
@@ -131,7 +131,7 @@ class AuthGuard extends AutoRouteGuard {
       if (value) {
         resolver.next(true);
       } else {
-        router.navigate(const LoginRoute());
+        router.replace(const LoginRoute());
       }
     }));
   }

--- a/lib/screens/login/login_screen.dart
+++ b/lib/screens/login/login_screen.dart
@@ -211,7 +211,7 @@ class _LoginPageState extends ConsumerState<LoginScreen> {
   void loggedInGoToHome() {
     ref.read(lockScreenActiveProvider.notifier).update((state) => false);
     if (context.mounted) {
-      context.router.navigate(const DashboardRoute());
+      context.router.replaceAll([const DashboardRoute()]);
     }
   }
 

--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -171,7 +171,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                               tooltip: context.localized.switchUser,
                               onPressed: () async {
                                 await ref.read(userProvider.notifier).logoutUser();
-                                context.router.navigate(const LoginRoute());
+                                context.router.replaceAll([const LoginRoute()]);
                               },
                               child: const Icon(
                                 IconsaxOutline.arrow_swap_horizontal,
@@ -208,7 +208,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                                         onPressed: () async {
                                           await ref.read(authProvider.notifier).logOutUser();
                                           if (context.mounted) {
-                                            context.router.navigate(const LoginRoute());
+                                            context.router.replaceAll([const LoginRoute()]);
                                           }
                                         },
                                         child: Text(context.localized.logout),


### PR DESCRIPTION
Fixes a small bug where the user could navigate back to the splashscreen when starting the app.
Also fixes switching users and going back from the login screen.