### PR TITLE
Add libmpv-dev to Linux workflow to fix compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,38 +198,38 @@ jobs:
           name: ${{ env.PACKAGE_NAME }}
           path: build/macos/Build/Products/Release/${{ env.PACKAGE_NAME }}.dmg
 
-  # build-linux:
-  #     runs-on: ubuntu-latest
+  build-linux:
+      runs-on: ubuntu-latest
 
-  #     steps:
-  #       - name: Checkout repository
-  #         uses: actions/checkout@v4.1.1
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4.1.1
 
-  #       - name: Set up Flutter
-  #         uses: subosito/flutter-action@v2.16.0
-  #         with:
-  #           channel: ${{ vars.FLUTTER_CHANNEL }}
-  #           flutter-version: ${{ vars.FLUTTER_VERSION }}
-  #           cache: true
-  #           cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to force refresh cache
-  #           cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
+        - name: Set up Flutter
+          uses: subosito/flutter-action@v2.16.0
+          with:
+            channel: ${{ vars.FLUTTER_CHANNEL }}
+            flutter-version: ${{ vars.FLUTTER_VERSION }}
+            cache: true
+            cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:" # optional, change this to force refresh cache
+            cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:" # optional, change this to specify the cache path
 
-  #       - name: Get dependencies
-  #         run: flutter pub get
+        - name: Get dependencies
+          run: flutter pub get
 
-  #       - name: Get packages
-  #         run: |
-  #           sudo apt-get update -y
-  #           sudo apt-get install -y ninja-build libgtk-3-dev
+        - name: Get packages
+          run: |
+            sudo apt-get update -y
+            sudo apt-get install -y ninja-build libgtk-3-dev libmpv-dev
 
-  #       - name: Build Linux app
-  #         run: flutter build linux
+        - name: Build Linux app
+          run: flutter build linux
 
-  #       - name: Archive Linux artifact
-  #         uses: actions/upload-artifact@v2
-  #         with:
-  #           name: linux
-  #           path: build/linux/x64/release/bundle
+        - name: Archive Linux artifact
+          uses: actions/upload-artifact@v2
+          with:
+            name: linux
+            path: build/linux/x64/release/bundle
 
   build-web:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hi there,

I managed to boil down the compilation issues to only Android and iOS, the former returning the error `Cannot use @TaskAction annotation on method IncrementalTask.taskAction$gradle_core() because interface org.gradle.api.tasks.incremental.IncrementalTaskInputs is not a valid parameter to an action method.` (the Kotlin version was also out of date, spewing dependency errors into the run log, that has since been fixed, I hope), and the latter returning the `No Team Found in Archive` error during the IPA export. The main build workflow has been deleted and replaced with separate workflows for compiling on desktop, mobile and GitHub Pages.

Feel free to test out my changes and if you have any issues, let me know. If you still want to collate the GH actions into a single file, I'd be happy to do it once the Android and iOS compilation issues are fixed.

<sub>Sorry for the amount of commits and the long rant. I was doing some experimenting, and there were some things that worked and some that didn't. This is my first foray into app development and there were some spots where I didn't know what I was doing.</sub>