### PR TITLE
Update GitHub upload-artifact version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,7 +226,7 @@ jobs:
           run: flutter build linux
 
         - name: Archive Linux artifact
-          uses: actions/upload-artifact@v2
+          uses: actions/upload-artifact@v4
           with:
             name: linux
             path: build/linux/x64/release/bundle


### PR DESCRIPTION
There's been some confusion, and my change to update the `upload-artifact` module in the Linux build was discarded when I synced my fork. Sorry about that!